### PR TITLE
Bug Fixed

### DIFF
--- a/fortinet-fortiproxy/info.json
+++ b/fortinet-fortiproxy/info.json
@@ -237,7 +237,7 @@
           "editable": true,
           "visible": true,
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned. The URL parameter is one of: vdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n",
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Action",
@@ -362,7 +362,7 @@
           "editable": true,
           "visible": true,
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf).",
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Filter",
@@ -371,7 +371,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Key",
@@ -444,7 +444,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -623,7 +623,7 @@
           "editable": true,
           "visible": true,
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf).",
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Action",
@@ -647,7 +647,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -960,7 +960,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -1053,7 +1053,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -1223,7 +1223,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -1348,7 +1348,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -1358,7 +1358,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Filter on Property",
@@ -1391,7 +1391,7 @@
           "tooltip": "Specify the scope based on which you want to retrieve firewall address from FortiProxy server. [global|vdom|both*]"
         },
         {
-          "title": "Exclude Properties",
+          "title": "Exclude Default Properties",
           "description": "Exclude properties/objects with default value",
           "name": "exclude-default-values",
           "required": false,
@@ -1431,7 +1431,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -1539,7 +1539,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -1564,7 +1564,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -1765,7 +1765,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -1858,7 +1858,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -2034,7 +2034,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -2149,7 +2149,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -2159,7 +2159,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Filter on Property",
@@ -2192,7 +2192,7 @@
           "tooltip": "Specify the scope based on which you want to retrieve firewall policy from FortiProxy server. [global|vdom|both*]"
         },
         {
-          "title": "Exclude Properties",
+          "title": "Exclude Default Properties",
           "description": "Exclude properties/objects with default value",
           "name": "exclude-default-values",
           "required": false,
@@ -2232,7 +2232,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -2330,7 +2330,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -2355,7 +2355,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json"
+          "type": "text"
         }
       ],
       "output_schema": {
@@ -2550,7 +2550,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -2624,7 +2624,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -2717,7 +2717,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -2832,7 +2832,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -2842,7 +2842,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json"
+          "type": "text"
         },
         {
           "title": "Filter on Property",
@@ -2875,7 +2875,7 @@
           "tooltip": "Specify the scope based on which you want to retrieve firewall policy from FortiProxy server [global|vdom|both*]"
         },
         {
-          "title": "Exclude Properties",
+          "title": "Exclude Default Properties",
           "description": "Specify the exclude properties/objects with default value based on which you want to retrieve firewall policy from FortiProxy server.",
           "name": "exclude-default-values",
           "required": false,
@@ -2915,7 +2915,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -3007,7 +3007,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "List of property names to include in results, separated by | (i.e. policyid|srcintf)."
         },
         {
@@ -3032,7 +3032,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],
@@ -3139,7 +3139,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         },
         {
@@ -3214,7 +3214,7 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "type": "json",
+          "type": "text",
           "tooltip": "Specify the Virtual Domain(s) from which results are returned or changes are applied to. If this parameter is not provided, the management VDOM will be used. If the admin does not have access to the VDOM, a permission error will be returned.\nThe URL parameter is one of:\nvdom=root (Single VDOM)\nvdom=vdom1,vdom2 (Multiple VDOMs)\nvdom=* (All VDOMs)\n"
         }
       ],

--- a/fortinet-fortiproxy/operations.py
+++ b/fortinet-fortiproxy/operations.py
@@ -66,6 +66,19 @@ def check_payload(payload):
     return updated_payload
 
 
+def convert_boolean_parameter_value_to_lower(params):
+    params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    params.update({'datasource': str(params.get('datasource')).lower()}) if params.get('datasource') else ''
+    params.update({'with_meta': str(params.get('with_meta')).lower()}) if params.get('with_meta') else ''
+    params.update({'with_contents_hash': str(params.get('with_contents_hash')).lower()}) if params.get(
+        'with_contents_hash') else ''
+    params.update({'skip': str(params.get('skip')).lower()}) if params.get('skip') else ''
+    params.update({'exclude-default-values': str(params.get('exclude-default-values')).lower()}) if params.get(
+        'exclude-default-values') else ''
+    params.update({'meta_only': str(params.get('meta_only')).lower()}) if params.get('meta_only') else ''
+    return params
+
+
 def create_firewall_policy(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/policy'
@@ -88,7 +101,7 @@ def create_firewall_policy(config, params):
 def get_firewall_policy(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/policy'
-    params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    convert_boolean_parameter_value_to_lower(params)
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -98,6 +111,9 @@ def get_firewall_policy_details(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/policy/{0}'.format(params.pop('policyid'))
     params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    params.update({'datasource': str(params.get('datasource')).lower()}) if params.get('datasource') else ''
+    params.update({'with_meta': str(params.get('with_meta')).lower()}) if params.get('with_meta') else ''
+    params.update({'skip': str(params.get('skip')).lower()}) if params.get('skip') else ''
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -154,7 +170,7 @@ def create_firewall_address(config, params):
 def get_firewall_address(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/address'
-    params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    convert_boolean_parameter_value_to_lower(params)
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -164,6 +180,9 @@ def get_firewall_address_details(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/address/{0}'.format(params.pop('name'))
     params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    params.update({'datasource': str(params.get('datasource')).lower()}) if params.get('datasource') else ''
+    params.update({'with_meta': str(params.get('with_meta')).lower()}) if params.get('with_meta') else ''
+    params.update({'skip': str(params.get('skip')).lower()}) if params.get('skip') else ''
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -217,7 +236,7 @@ def create_firewall_address_group(config, params):
 def get_firewall_address_group(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/addrgrp'
-    params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    convert_boolean_parameter_value_to_lower(params)
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -227,6 +246,9 @@ def get_firewall_address_group_details(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall/addrgrp/{0}'.format(params.pop('name'))
     params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    params.update({'datasource': str(params.get('datasource')).lower()}) if params.get('datasource') else ''
+    params.update({'with_meta': str(params.get('with_meta')).lower()}) if params.get('with_meta') else ''
+    params.update({'skip': str(params.get('skip')).lower()}) if params.get('skip') else ''
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -274,7 +296,7 @@ def create_firewall_service_group(config, params):
 def get_firewall_service_group(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall.service/group'
-    params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    convert_boolean_parameter_value_to_lower(params)
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -284,6 +306,9 @@ def get_firewall_service_group_details(config, params):
     fp = FortiProxy(config)
     endpoint = 'cmdb/firewall.service/group/{0}'.format(params.pop('name'))
     params.update({'action': params.get('action').lower()}) if params.get('action') else ''
+    params.update({'datasource': str(params.get('datasource')).lower()}) if params.get('datasource') else ''
+    params.update({'with_meta': str(params.get('with_meta')).lower()}) if params.get('with_meta') else ''
+    params.update({'skip': str(params.get('skip')).lower()}) if params.get('skip') else ''
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -315,6 +340,8 @@ def delete_firewall_service_group(config, params):
 def get_authenticated_firewall_users_list(config, params):
     fp = FortiProxy(config)
     endpoint = 'monitor/user/firewall'
+    params.update({'ipv4': str(params.get('ipv4')).lower()}) if params.get('ipv4') else ''
+    params.update({'ipv6': str(params.get('ipv6')).lower()}) if params.get('ipv6') else ''
     query_parameter = {k: v for k, v in params.items() if v is not None and v != ''}
     response = fp.make_rest_call(endpoint, 'GET', params=query_parameter)
     return response
@@ -323,6 +350,7 @@ def get_authenticated_firewall_users_list(config, params):
 def deauthenticate_firewall_users(config, params):
     fp = FortiProxy(config)
     endpoint = 'monitor/firewall/deauth'
+    params.update({'all': str(params.get('all')).lower()}) if params.get('all') else ''
     payload = check_payload(params)
     response = fp.make_rest_call(endpoint, 'POST', params={}, data=json.dumps(payload))
     return response


### PR DESCRIPTION
#### Mantis:

- [0891316](https://mantis.fortinet.com/bug_view_page.php?bug_id=0891316) : Action "Get Firewall Service Group" does not honour checked input field
- [0891781](https://mantis.fortinet.com/bug_view_page.php?bug_id=0891781) : Input param "Include Property" and "Filter" can be provided as text field instead of JSON as API demands only string.
- [0892206](https://mantis.fortinet.com/bug_view_page.php?bug_id=0892206) : Change "Exclude Properties" param name to "Exclude Default Properties" and also update the tooltip

#### UTCs:

- [x] Verified all operations.