### PR TITLE
Bug Fixed

### DIFF
--- a/fortinet-fortiproxy/info.json
+++ b/fortinet-fortiproxy/info.json
@@ -199,16 +199,6 @@
             ],
             "SSH": [
               {
-                "title": "Source Interface",
-                "description": "Specify the incoming (ingress) interface of the firewall policy that you want to create in the FortiProxy server.",
-                "name": "srcintf",
-                "required": true,
-                "editable": true,
-                "visible": true,
-                "tooltip": "Specify the incoming (ingress) interface of the firewall policy that you want to create in the FortiProxy server. Note: Maximum length should be 79.",
-                "type": "json"
-              },
-              {
                 "title": "Destination Interface",
                 "description": "Specify the outgoing (egress) interface of the firewall policy that you want to create in the FortiProxy server.",
                 "name": "dstintf",
@@ -221,6 +211,16 @@
             ],
             "Access Proxy": [
               {
+                "title": "Access Proxy",
+                "description": "Specify the access proxy of the firewall policy that you want to create in the FortiProxy server. Note: The maximum length that can be set is 79.",
+                "name": "access-proxy",
+                "required": true,
+                "editable": true,
+                "visible": true,
+                "tooltip": "Specify the access proxy of the firewall policy that you want to create in the FortiProxy server. Note: The maximum length that can be set is 79.",
+                "type": "json"
+              },
+              {
                 "title": "Destination Interface",
                 "description": "Specify the outgoing (egress) interface of the firewall policy that you want to create in the FortiProxy server.",
                 "name": "dstintf",
@@ -228,16 +228,6 @@
                 "editable": true,
                 "visible": true,
                 "tooltip": "Specify the outgoing (egress) interface of the firewall policy that you want to create in the FortiProxy server. Note: Maximum length should be 79.",
-                "type": "json"
-              },
-              {
-                "title": "Access Proxy",
-                "description": "(Optional) Specify the access proxy of the firewall policy that you want to create in the FortiProxy server. Note: The maximum length that can be set is 79.",
-                "name": "access-proxy",
-                "required": false,
-                "editable": true,
-                "visible": true,
-                "tooltip": "(Optional) Specify the access proxy of the firewall policy that you want to create in the FortiProxy server. Note: The maximum length that can be set is 79.",
                 "type": "json"
               }
             ],
@@ -256,20 +246,10 @@
           }
         },
         {
-          "title": "Policy ID",
-          "description": "(Optional) Specify the ID of the firewall policy that you want to create in the FortiProxy server.",
-          "name": "policyid",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "tooltip": "(Optional) Specify the ID of the firewall policy that you want to create in the FortiProxy server. Note: Size should be between 0 to 4294967294.",
-          "type": "integer"
-        },
-        {
           "title": "Source Address",
           "description": "(Optional) Specify the source address and address group names to be associated with the firewall policy you want to create in the FortiProxy server.",
           "name": "srcaddr",
-          "required": false,
+          "required": true,
           "editable": true,
           "visible": true,
           "tooltip": "(Optional) Specify the source address and address group names to be associated with the firewall policy you want to create in the FortiProxy server. Note: Maximum length should be 79.",
@@ -279,7 +259,7 @@
           "title": "Destination Address",
           "description": "(Optional) Specify the destination address and address group names to be associated with the firewall policy you want to create in the FortiProxy server.",
           "name": "dstaddr",
-          "required": false,
+          "required": true,
           "editable": true,
           "visible": true,
           "tooltip": "(Optional) Specify the destination address and address group names to be associated with the firewall policy you want to create in the FortiProxy server. Note: Maximum length should be 79.",
@@ -289,7 +269,7 @@
           "title": "IPV6 Source Address",
           "description": "(Optional) Specify the IPv6 source address (web proxy only) of the firewall policy you want to create in the FortiProxy server.",
           "name": "srcaddr6",
-          "required": false,
+          "required": true,
           "editable": true,
           "visible": true,
           "tooltip": "(Optional) Specify the IPv6 source address (web proxy only) of the firewall policy you want to create in the FortiProxy server. Note: Maximum length should be 79.",
@@ -299,11 +279,21 @@
           "title": "IPV6 Destination Address",
           "description": "(Optional) Specify the IPv6 destination address (web proxy only) of the firewall policy that you want to create in the FortiProxy server.",
           "name": "dstaddr6",
-          "required": false,
+          "required": true,
           "editable": true,
           "visible": true,
           "tooltip": "(Optional) Specify the IPv6 destination address (web proxy only) of the firewall policy that you want to create in the FortiProxy server. Note: Maximum length should be 79.",
           "type": "json"
+        },
+        {
+          "title": "Policy ID",
+          "description": "(Optional) Specify the ID of the firewall policy that you want to create in the FortiProxy server.",
+          "name": "policyid",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "tooltip": "(Optional) Specify the ID of the firewall policy that you want to create in the FortiProxy server. Note: Size should be between 0 to 4294967294.",
+          "type": "integer"
         },
         {
           "title": "Policy Action",

--- a/fortinet-fortiproxy/info.json
+++ b/fortinet-fortiproxy/info.json
@@ -93,6 +93,16 @@
           "onchange": {
             "Explicit Web": [
               {
+                "title": "Explicit Web Proxy",
+                "description": "Specify the explicit web proxy of the firewall policy that you want to create in the FortiProxy server.",
+                "name": "explicit-web-proxy",
+                "required": true,
+                "editable": true,
+                "visible": true,
+                "tooltip": "Specify the explicit web proxy of the firewall policy that you want to create in the FortiProxy server. Note: Maximum length should be 35.",
+                "type": "text"
+              },
+              {
                 "title": "Destination Interface",
                 "description": "Specify the outgoing (egress) interface of the firewall policy that you want to create in the FortiProxy server.",
                 "name": "dstintf",
@@ -137,20 +147,6 @@
                 "visible": true,
                 "tooltip": "Specify the outgoing (egress) interface of the firewall policy that you want to create in the FortiProxy server. Note: Maximum length should be 79.",
                 "type": "json"
-              },
-              {
-                "title": "Status",
-                "description": "(Optional) Select the status to be set for the firewall policy that you want to create in the FortiProxy server. You can choose between enable or disable.",
-                "name": "status",
-                "required": false,
-                "editable": true,
-                "visible": true,
-                "type": "select",
-                "tooltip": "(Optional) Select the status to be set for the firewall policy that you want to create in the FortiProxy server. You can choose between enable or disable.",
-                "options": [
-                  "enable",
-                  "disable"
-                ]
               },
               {
                 "title": "Force Proxy",
@@ -323,6 +319,20 @@
             "Deny",
             "Redirect",
             "Isolate"
+          ]
+        },
+        {
+          "title": "Status",
+          "description": "(Optional) Select the status to be set for the firewall policy that you want to create in the FortiProxy server. You can choose between enable or disable.",
+          "name": "status",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "select",
+          "tooltip": "(Optional) Select the status to be set for the firewall policy that you want to create in the FortiProxy server. You can choose between enable or disable.",
+          "options": [
+            "enable",
+            "disable"
           ]
         },
         {
@@ -1027,20 +1037,6 @@
                 "type": "json"
               },
               {
-                "title": "Status",
-                "description": "Specify the status for the policy, from the following available options: enable: Enable setting for this policy or disable: Disable setting for this policy.",
-                "name": "status",
-                "required": false,
-                "editable": true,
-                "visible": true,
-                "type": "select",
-                "tooltip": "Specify the status for the policy, from the following available options: enable: Enable setting for this policy or disable: Disable setting for this policy.",
-                "options": [
-                  "enable",
-                  "disable"
-                ]
-              },
-              {
                 "title": "Force Proxy",
                 "description": "Specify the force proxy for the policy, from the following available options: enable: Force all TCP transparent traffic to proxy or disable: Do not force TCP transparent traffic to proxy.",
                 "name": "force-proxy",
@@ -1148,16 +1144,6 @@
           }
         },
         {
-          "title": "Policy ID",
-          "description": "Specify the ID of the policy whose firewall policy that you want to create in FortiProxy server.",
-          "name": "policyid",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "tooltip": "Specify the ID of the policy whose firewall policy that you want to create in FortiProxy server. Note: Size should be between 0 to 4294967294.",
-          "type": "integer"
-        },
-        {
           "title": "Source Address",
           "description": "Specify the source address and address group names whose firewall policy that you want to create in FortiProxy server.",
           "name": "srcaddr",
@@ -1211,6 +1197,20 @@
             "Deny",
             "Redirect",
             "Isolate"
+          ]
+        },
+        {
+          "title": "Status",
+          "description": "Specify the status for the policy, from the following available options: enable: Enable setting for this policy or disable: Disable setting for this policy.",
+          "name": "status",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "select",
+          "tooltip": "Specify the status for the policy, from the following available options: enable: Enable setting for this policy or disable: Disable setting for this policy.",
+          "options": [
+            "enable",
+            "disable"
           ]
         },
         {
@@ -2760,20 +2760,6 @@
           "visible": true,
           "type": "text",
           "tooltip": "Specify the address group name based on which you want to update the firewall address group in FortiProxy server. Note: Maximum length should be 79."
-        },
-        {
-          "title": "Address Group Type",
-          "name": "type",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "select",
-          "description": "Specify the type of the address group, from the following available options: Default: Default address group type (address may belong to multiple groups) or Folder: Address folder group (members may not belong to any other group).",
-          "options": [
-            "Default",
-            "Folder"
-          ],
-          "tooltip": "Specify the type of the address group, from the following available options: Default: Default address group type (address may belong to multiple groups) or Folder: Address folder group (members may not belong to any other group)."
         },
         {
           "title": "Member",

--- a/fortinet-fortiproxy/operations.py
+++ b/fortinet-fortiproxy/operations.py
@@ -257,7 +257,6 @@ def update_firewall_address_group(config, params):
         'before': params.pop('before', ''),
         'after': params.get('after', '')
     }
-    params.update({'type': params.get('type').lower() if params.get('type') else ''})
     custom_attributes = params.pop('custom_attributes', '')
     if custom_attributes:
         params.update(custom_attributes)


### PR DESCRIPTION
#### Mantis:

- [0902904](https://mantis.fortinet.com/bug_view_page.php?bug_id=0902904) : Mandatory param 'explicit-web-proxy' is required when policy type "Explicit Web" is selected
- [0902912](https://mantis.fortinet.com/bug_view_page.php?bug_id=0902912) : Input field "Policy ID" appears twice for action "Update Firewall Policy"
- [0899818](https://mantis.fortinet.com/bug_view_page.php?bug_id=0899818) : Create Firewall Address Group, remove/modify some of the params to keep consistency with the setup/UI

#### UTCs:

- [x] Verified "Create Firewall Policy", "Update Firewall Policy", and "Create Firewall Address Group" operation.